### PR TITLE
支持导出时使用新版的orgmode

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ hexo.config.org = assign({
   toc: false,
   emacs: 'emacs',
   common: '',
+  export_cfg: "(progn (package-initialize)(require 'org) (require 'org-clock) (require 'ox))",
   cachedir: './hexo-org-cache/'
 }, hexo.config.org);
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -120,12 +120,16 @@ function print_warning(err, path) {
     "Warning: arch-dependent data dir '/Users/build/workspace/Emacs-Multi-Build/label/mavericks/emacs-source/nextstep/Emacs.app/Contents/MacOS/libexec/': No such file or directory",
     'Cannot fontify src block (htmlize.el >= 1.34 required)',
     'Cannot fontify src block (htmlize.el >= 1.34 required)\r', // for Windows
-    ''
+      '',
+      'Extension ignored',
+      'Indentation variables are now local.',
+      'Setting up indent for shell type bash',
+      'Indentation setup for shell type bash'
   ];
   var lines = err.split('\n');
   var msg = '';
   for (var i = 0; i < lines.length; i++) {
-    if (useless.indexOf(lines[i]) < 0) {
+      if (useless.indexOf(lines[i].trim()) < 0) {
       msg = msg + lines[i] + '\n';
     }
   }
@@ -167,12 +171,14 @@ function convert(data, config) {
   (insert "${config.org.common}\n")
   ;; reload org setting https://lists.gnu.org/archive/html/emacs-orgmode/2014-01/msg00648.html
   (normal-mode)
-  (unless (derived-mode-p "org-mode")
+  (unless (derived-mode-p 'org-mode)
     (org-mode))
   (org-html-export-as-html nil nil nil nil nil)
   (message "${flag}%s${flag}" (buffer-string)))
   `;
-    var exec_args = [data.path, '--batch', '--kill', '--execute', emacs_lisp];
+    var exec_args = ['--batch', data.path, '--execute',emacs_lisp];
+    if (config.org.export_cfg != '')
+        exec_args.splice(1,0,'--execute', config.org.export_cfg)
     var proc = spawn(emacs_path, exec_args);
     // I dont know why it output to stderr..
     var bufferHelper = new BufferHelper();

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ describe('Org renderer', function() {
     config: {
       org: {
         emacs: 'emacs',
+        export_cfg: '',
         common: '#+OPTIONS: html-postamble:nil'
       }
     }


### PR DESCRIPTION
原导出函数使用batch模式时默认使用内置的orgmode版本（8.2.10），但有些特性不支持。增加export_cfg设置项允许自己设置和添加导出时的一些设定。默认使用安装 的最新版orgmode（9.x）进行导出，这样可以使用新版orgmode的特性。（我提的#40ISSUE就属于此例）另外也方便可以自己增加一些设置，如：增加babel支持的语言种类等

可以通过 在配置文件中将export_cfg设为''来继续使用内置版本。另增加了一些可以过滤的告警信息，原信息过滤函数里未作trim处理会造成过滤失效

英文差，README中就没有添加说明了