### PR TITLE
从根源解决网页诡异的重复转义html实体问题

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -62,6 +62,7 @@ function htmlUnescape(str){
     return str
         .replace(/&quot;/g, '"')
         .replace(/&#39;/g, "'")
+        .replace(/&#38;/g, "&")
         .replace(/&lt;/g, '<')
         .replace(/&gt;/g, '>')
         .replace(/&amp;/g, '&');
@@ -92,7 +93,7 @@ function renderer(data) {
                         + JSON.stringify(config.highlight));
       if(cache.md5 == content_md5){ // hit cache
         console.log(`${data.path} completed with cache`);
-        resolve(cache.content);
+        resolve(htmlUnescape(cache.content));
         return;
       }
     }

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -10,6 +10,7 @@ var jsonfile = require('jsonfile');
 var md5 = require('md5');
 var fs = require('fs');
 var mkdirp = require('mkdirp');
+var he = require("he");
 
 var highlight = util.highlight;
 
@@ -46,7 +47,7 @@ function render_html(html, config) {
       var text; // await highlight code text
       var lang = 'unknown';
       var code = $(this);
-      text = code.text().replace(/\n$/g,'');
+      text = he.decode(code.text()).replace(/\n$/g,'');
       var class_str = code.attr('class');
       if (class_str.startsWith('src src-')) {
         lang = class_str.substring('src src-'.length);
@@ -58,15 +59,6 @@ function render_html(html, config) {
   });
 }
 
-function htmlUnescape(str){
-    return str
-        .replace(/&quot;/g, '"')
-        .replace(/&#39;/g, "'")
-        .replace(/&#38;/g, "&")
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&amp;/g, '&');
-}
 
 function renderer(data) {
   var config = this.config;
@@ -93,7 +85,7 @@ function renderer(data) {
                         + JSON.stringify(config.highlight));
       if(cache.md5 == content_md5){ // hit cache
         console.log(`${data.path} completed with cache`);
-        resolve(htmlUnescape(cache.content));
+        resolve(cache.content);
         return;
       }
     }
@@ -108,7 +100,7 @@ function renderer(data) {
           cache.content = result;
           jsonfile.writeFileSync(cachefile, cache);
         }
-        resolve(htmlUnescape(result));
+        resolve(result);
     });
   });
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bufferhelper": "^0.2.1",
     "cheerio": "^0.19.0",
+    "he": "^1.1.1",
     "hexo-util": "^0.1.7",
     "iconv-lite": "^0.4.13",
     "jsonfile": "^2.2.3",


### PR DESCRIPTION
老哥，你这个：
https://github.com/CodeFalling/hexo-renderer-org/commit/6b815f29baf50189cd686c59737f05f91beae8dc
修复的思路不对。有时候还是有问题。

真正的问题出在这：
https://github.com/cheeriojs/cheerio/issues/52
cheerio的text()方法没有把html实体还原，导致后面重复转义了实体。