### PR TITLE
修复代码块行号不显示的问题

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -212,10 +212,23 @@ function highlighted(code, lang, config) {
      gutter = config.highlight.line_number;
   }
 
-  return highlight(code, {
+  var highlight_html = highlight(code, {
     gutter: gutter,
     lang: lang
   });
+
+// A ugly patch, temporarily hide the bug: https://github.com/hexojs/hexo/issues/1543
+    var $ = cheerio.load(highlight_html);
+    var figure_class = $('figure').attr("class");
+    var is_plain = figure_class == 'highlight' || figure_class == 'highlight plain';
+    if (is_plain) {
+        highlight_html = highlight(code, {
+            gutter: false,
+            lang: lang
+        });
+    }
+
+  return highlight_html;
 }
 
 module.exports = renderer;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -205,8 +205,15 @@ function highlighted(code, lang, config) {
    * @param {String} options https://github.com/hexojs/hexo-util#highlightstr-options
    * @returns {String} result
    */
+  var gutter;
+  if (code.split("\n").length <= 1) {
+     gutter = false;
+  } else {
+     gutter = config.highlight.line_number;
+  }
+
   return highlight(code, {
-    gutter: config.highlight.number,
+    gutter: gutter,
     lang: lang
   });
 }


### PR DESCRIPTION
老哥，那个代码块行号，_config.yml里写的是`line_number`, 但是你代码里写的是`number`。
更新：
1. 使得_config.yml的line_number设置重新有效
2. 对于只有一行的代码，不显示行号，影响美观
3. 隐藏bug https://github.com/hexojs/hexo/issues/1543 。此bug会导致代码块语言为plain或不能识别的语言时，行号显示异常。解决方法是对这类代码块不显示行号。